### PR TITLE
Removed invalid 'dev' environment

### DIFF
--- a/.github/workflows/continuous-integration-dotnet.yml
+++ b/.github/workflows/continuous-integration-dotnet.yml
@@ -12,7 +12,6 @@ on:
 jobs:
   build-test:
     runs-on: ubuntu-latest
-    environment: dev
     env:
       # Note: The database name may be overridden by the tests
       CONNECTION_STRING: 'Server=localhost,1433;Database=integrationtests;User Id=sa;Password=P1swrd!$;TrustServerCertificate=True'


### PR DESCRIPTION
The .NET build test should run on any environment and not be limited to 'development'