### PR TITLE
Use new container app module

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -137,7 +137,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_azure_container_apps_hosting"></a> [azure\_container\_apps\_hosting](#module\_azure\_container\_apps\_hosting) | github.com/DFE-Digital/terraform-azurerm-container-apps-hosting | v0.19.4 |
+| <a name="module_azure_container_apps_hosting"></a> [azure\_container\_apps\_hosting](#module\_azure\_container\_apps\_hosting) | github.com/DFE-Digital/terraform-azurerm-container-apps-hosting | refactor-container-app-resources |
 | <a name="module_azurerm_key_vault"></a> [azurerm\_key\_vault](#module\_azurerm\_key\_vault) | github.com/DFE-Digital/terraform-azurerm-key-vault-tfvars | v0.2.0 |
 
 ## Resources
@@ -153,6 +153,7 @@ No resources.
 | <a name="input_cdn_frontdoor_enable_rate_limiting"></a> [cdn\_frontdoor\_enable\_rate\_limiting](#input\_cdn\_frontdoor\_enable\_rate\_limiting) | Enable CDN Front Door Rate Limiting. This will create a WAF policy, and CDN security policy. For pricing reasons, there will only be one WAF policy created. | `bool` | n/a | yes |
 | <a name="input_cdn_frontdoor_forwarding_protocol"></a> [cdn\_frontdoor\_forwarding\_protocol](#input\_cdn\_frontdoor\_forwarding\_protocol) | Azure CDN Front Door forwarding protocol | `string` | `"HttpsOnly"` | no |
 | <a name="input_cdn_frontdoor_health_probe_path"></a> [cdn\_frontdoor\_health\_probe\_path](#input\_cdn\_frontdoor\_health\_probe\_path) | Specifies the path relative to the origin that is used to determine the health of the origin. | `string` | n/a | yes |
+| <a name="input_cdn_frontdoor_health_probe_protocol"></a> [cdn\_frontdoor\_health\_probe\_protocol](#input\_cdn\_frontdoor\_health\_probe\_protocol) | Use Http or Https | `string` | `"Https"` | no |
 | <a name="input_cdn_frontdoor_host_add_response_headers"></a> [cdn\_frontdoor\_host\_add\_response\_headers](#input\_cdn\_frontdoor\_host\_add\_response\_headers) | List of response headers to add at the CDN Front Door `[{ "name" = "Strict-Transport-Security", "value" = "max-age=31536000" }]` | `list(map(string))` | n/a | yes |
 | <a name="input_cdn_frontdoor_origin_fqdn_override"></a> [cdn\_frontdoor\_origin\_fqdn\_override](#input\_cdn\_frontdoor\_origin\_fqdn\_override) | Manually specify the hostname that the CDN Front Door should target. Defaults to the Container App FQDN | `string` | `""` | no |
 | <a name="input_cdn_frontdoor_origin_host_header_override"></a> [cdn\_frontdoor\_origin\_host\_header\_override](#input\_cdn\_frontdoor\_origin\_host\_header\_override) | Manually specify the host header that the CDN sends to the target. Defaults to the recieved host header. Set to null to set it to the host\_name (`cdn_frontdoor_origin_fqdn_override`) | `string` | `""` | no |
@@ -166,6 +167,7 @@ No resources.
 | <a name="input_dns_txt_records"></a> [dns\_txt\_records](#input\_dns\_txt\_records) | DNS TXT records to add to the DNS Zone | <pre>map(<br>    object({<br>      ttl : optional(number, 300),<br>      records : list(string)<br>    })<br>  )</pre> | n/a | yes |
 | <a name="input_dns_zone_domain_name"></a> [dns\_zone\_domain\_name](#input\_dns\_zone\_domain\_name) | DNS zone domain name. If created, records will automatically be created to point to the CDN. | `string` | n/a | yes |
 | <a name="input_enable_cdn_frontdoor"></a> [enable\_cdn\_frontdoor](#input\_enable\_cdn\_frontdoor) | Enable Azure CDN FrontDoor. This will use the Container Apps endpoint as the origin. | `bool` | n/a | yes |
+| <a name="input_enable_container_health_probe"></a> [enable\_container\_health\_probe](#input\_enable\_container\_health\_probe) | Enable liveness probes for the Container | `bool` | `true` | no |
 | <a name="input_enable_container_registry"></a> [enable\_container\_registry](#input\_enable\_container\_registry) | Set to true to create a container registry | `bool` | n/a | yes |
 | <a name="input_enable_dns_zone"></a> [enable\_dns\_zone](#input\_enable\_dns\_zone) | Conditionally create a DNS zone | `bool` | n/a | yes |
 | <a name="input_enable_event_hub"></a> [enable\_event\_hub](#input\_enable\_event\_hub) | Send Azure Container App logs to an Event Hub sink | `bool` | n/a | yes |

--- a/terraform/container-apps-hosting.tf
+++ b/terraform/container-apps-hosting.tf
@@ -1,5 +1,5 @@
 module "azure_container_apps_hosting" {
-  source = "github.com/DFE-Digital/terraform-azurerm-container-apps-hosting?ref=v0.19.4"
+  source = "github.com/DFE-Digital/terraform-azurerm-container-apps-hosting?ref=refactor-container-app-resources"
 
   environment    = local.environment
   project_name   = local.project_name
@@ -42,11 +42,13 @@ module "azure_container_apps_hosting" {
   cdn_frontdoor_origin_host_header_override       = local.cdn_frontdoor_origin_host_header_override
   container_apps_allow_ips_inbound                = local.container_apps_allow_ips_inbound
 
-  enable_monitoring               = local.enable_monitoring
-  monitor_email_receivers         = local.monitor_email_receivers
-  container_health_probe_path     = local.container_health_probe_path
-  cdn_frontdoor_health_probe_path = local.cdn_frontdoor_health_probe_path
-  monitor_endpoint_healthcheck    = local.monitor_endpoint_healthcheck
+  enable_monitoring                   = local.enable_monitoring
+  monitor_email_receivers             = local.monitor_email_receivers
+  container_health_probe_path         = local.container_health_probe_path
+  cdn_frontdoor_health_probe_path     = local.cdn_frontdoor_health_probe_path
+  monitor_endpoint_healthcheck        = local.monitor_endpoint_healthcheck
+  enable_container_health_probe       = local.enable_container_health_probe
+  cdn_frontdoor_health_probe_protocol = local.cdn_frontdoor_health_probe_protocol
 
   existing_logic_app_workflow                  = local.existing_logic_app_workflow
   existing_network_watcher_name                = local.existing_network_watcher_name

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -37,8 +37,10 @@ locals {
   tfvars_filename                                 = var.tfvars_filename
   enable_monitoring                               = var.enable_monitoring
   monitor_email_receivers                         = var.monitor_email_receivers
+  enable_container_health_probe                   = var.enable_container_health_probe
   container_health_probe_path                     = var.container_health_probe_path
   cdn_frontdoor_health_probe_path                 = var.cdn_frontdoor_health_probe_path
+  cdn_frontdoor_health_probe_protocol             = var.cdn_frontdoor_health_probe_protocol
   monitor_endpoint_healthcheck                    = var.monitor_endpoint_healthcheck
   existing_logic_app_workflow                     = var.existing_logic_app_workflow
   existing_network_watcher_name                   = var.existing_network_watcher_name

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -249,3 +249,15 @@ variable "dns_txt_records" {
     })
   )
 }
+
+variable "enable_container_health_probe" {
+  description = "Enable liveness probes for the Container"
+  type        = bool
+  default     = true
+}
+
+variable "cdn_frontdoor_health_probe_protocol" {
+  description = "Use Http or Https"
+  type        = string
+  default     = "Https"
+}


### PR DESCRIPTION
**What does this change do?**
- disables the container app monitor for the time being
- switch to using http health check for front door
- use branched version of the container app module so we can test refactored code

**Why do we need it?**
- Currently the container app liveness probe fails and the container crashes, this is a false positive so for the time being I am switching off the monitor until there is a working health check endpoint
- https requests are also failing to be responded to by the container but switching to http works
- Using the branched version of the module allows us to leverage the new refactored terraform code in the latest major version of the module which is currently unreleased but being tested (by this app!)