### PR TITLE
fixed issue where tasks would not load without dependent data

### DIFF
--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.API/Controllers/ProjectTaskController.cs
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.API/Controllers/ProjectTaskController.cs
@@ -41,6 +41,12 @@ namespace Dfe.ManageFreeSchoolProjects.API.Controllers
 
             var projectByTask = await _getProjectByTaskService.Execute(projectId);
 
+            if (projectByTask == null) 
+            {
+                _logger.LogInformation("No project could be found for the given project id {projectId}", projectId);
+                return new NotFoundResult();
+            }
+
             var result = new ApiSingleResponseV2<GetProjectByTaskResponse>(projectByTask);
 
             return new ObjectResult(result) { StatusCode = StatusCodes.Status200OK };

--- a/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.API/UseCases/Project/Tasks/GetProjectByTaskService.cs
+++ b/Dfe.ManageFreeSchoolProjects/Dfe.ManageFreeSchoolProjects.API/UseCases/Project/Tasks/GetProjectByTaskService.cs
@@ -24,10 +24,14 @@ namespace Dfe.ManageFreeSchoolProjects.API.UseCases.Project.Tasks
             var result = await
                 (from kpi in _context.Kpi
                 where kpi.ProjectStatusProjectId == projectId
-                join kai in _context.Kai on kpi.Rid equals kai.Rid
-                join property in _context.Property on kpi.Rid equals property.Rid
-                join trust in _context.Trust on kpi.Rid equals trust.Rid
-                join construction in _context.Construction on kpi.Rid equals construction.Rid
+                join kai in _context.Kai on kpi.Rid equals kai.Rid into kaiJoin
+                from kai in kaiJoin.DefaultIfEmpty()
+                join property in _context.Property on kpi.Rid equals property.Rid into propertyJoin
+                from property in propertyJoin.DefaultIfEmpty()
+                join trust in _context.Trust on kpi.Rid equals trust.Rid into trustJoin
+                from trust in trustJoin.DefaultIfEmpty()
+                join construction in _context.Construction on kpi.Rid equals construction.Rid into constructionJoin
+                from construction in constructionJoin.DefaultIfEmpty()
                 select new GetProjectByTaskResponse()
                 {
                     School = new SchoolTask()


### PR DESCRIPTION
changed inner joins to left outer joins for get project by task so the project is still returned

handle when project cannot be found by returning a 404