### PR TITLE
Update the API container revision on push

### DIFF
--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -115,15 +115,18 @@ jobs:
     needs: [ build-and-push-image, set-env ]
     runs-on: ubuntu-22.04
     environment: ${{ needs.set-env.outputs.environment }}
+    strategy:
+      matrix:
+        image: ['web', 'api']
     steps:
       - name: Azure login with ACA credentials
         uses: azure/login@v1
         with:
           creds: ${{ secrets.AZURE_ACA_CREDENTIALS }}
 
-      - name: Update Azure Container Apps Revision
+      - name: Update Web Container Revision
         uses: azure/CLI@v1
-        id: azure
+        if: matrix.image == 'web'
         with:
           azcliversion: 2.45.0
           inlineScript: |
@@ -131,5 +134,18 @@ jobs:
             az containerapp update \
               --name ${{ secrets.AZURE_ACA_NAME }} \
               --resource-group ${{ secrets.AZURE_ACA_RESOURCE_GROUP }} \
-              --image ${{ secrets.AZURE_ACR_URL }}/${{ env.DOCKER_IMAGE }}:${{ needs.set-env.outputs.release }} \
+              --image ${{ secrets.AZURE_ACR_URL }}/${{ env.DOCKER_IMAGE }}:${{ matrix.image }}-${{ needs.set-env.outputs.release }} \
+              --output none
+
+      - name: Update API Container Revision
+        uses: azure/CLI@v1
+        if: matrix.image == 'api'
+        with:
+          azcliversion: 2.45.0
+          inlineScript: |
+            az config set extension.use_dynamic_install=yes_without_prompt
+            az containerapp update \
+              --name ${{ secrets.AZURE_API_ACA_NAME }} \
+              --resource-group ${{ secrets.AZURE_ACA_RESOURCE_GROUP }} \
+              --image ${{ secrets.AZURE_ACR_URL }}/${{ env.DOCKER_IMAGE }}:${{ matrix.image }}-${{ needs.set-env.outputs.release }} \
               --output none


### PR DESCRIPTION
- The azure container app revision update task uses the correct image tag
- The image tag has been updated to reflect the changes in [this commit](https://github.com/DFE-Digital/manage-free-schools-projects/pull/141/commits/97b4d3605d3fb9ec3f72853ae6b5feb2c5039fc2)
- The task now uses matrix to concurrently update both the web and api containers at the same time
- This is a fix for [failing deployments](https://github.com/DFE-Digital/manage-free-schools-projects/actions/runs/6156618108/job/16705852814)